### PR TITLE
Fixed rotary_irq file (not updated to last version)

### DIFF
--- a/rotary_irq_rp2.py
+++ b/rotary_irq_rp2.py
@@ -1,4 +1,4 @@
-# The MIT License (MIT)
+# MIT License (MIT)
 # Copyright (c) 2020 Mike Teachman
 # Copyright (c) 2021 Eric Moyer
 # https://opensource.org/licenses/MIT
@@ -8,7 +8,8 @@
 
 # Documentation:
 #   https://github.com/MikeTeachman/micropython-rotary
-
+# From the repo:
+# https://github.com/miketeachman/micropython-rotary/blob/master/rotary_irq_rp2.py
 from machine import Pin
 from rotary import Rotary
 
@@ -22,12 +23,14 @@ class RotaryIRQ(Rotary):
         pin_num_dt,
         min_val=0,
         max_val=10,
+        incr=1,
         reverse=False,
         range_mode=Rotary.RANGE_UNBOUNDED,
         pull_up=False,
         half_step=False,
+        invert=False
     ):
-        super().__init__(min_val, max_val, reverse, range_mode, half_step)
+        super().__init__(min_val, max_val, incr, reverse, range_mode, half_step, invert)
 
         if pull_up:
             self._pin_clk = Pin(pin_num_clk, Pin.IN, Pin.PULL_UP)


### PR DESCRIPTION
When compiling it gave the error "TypeError: function takes 8 positional arguments but 6 were given" because the library file was not updated